### PR TITLE
added a resolver that generates random passwords

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
             'package_version = uc3_sceptre_utils.resolvers.package_version:PackageVersion',
             'hosted_zone_id = uc3_sceptre_utils.resolvers.hosted_zone_id:HostedZoneId',
             'ssm_parameter = uc3_sceptre_utils.resolvers.ssm_parameter:SsmParameter',
+            'password_generator = uc3_sceptre_utils.resolvers.password_generator:PasswordGenerator',
         ],
     },
 )

--- a/uc3_sceptre_utils/resolvers/password_generator.py
+++ b/uc3_sceptre_utils/resolvers/password_generator.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+import random
+import string
+
+from sceptre.resolvers import Resolver
+from sceptre.exceptions import InvalidHookArgumentSyntaxError
+from uc3_sceptre_utils.util import route53, DEFAULT_REGION
+
+
+class PasswordGenerator(Resolver):
+    """
+    Returns a random password based on the following arguments:
+      0 - integer - length
+      1 - boolean - whether or not to include special characters
+
+    Example sceptre config usage:
+      RdsPassword: !password_generator 12, true
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(PasswordGenerator, self).__init__(*args, **kwargs)
+
+    def resolve(self):
+        if len(self.argument.split()) == 2:
+          length, allow_chars = self.argument.split()
+        else:
+          raise InvalidHookArgumentSyntaxError(
+            '{}: Resolver requires two arguments: length (Int) and allow special chars (Bool) - '
+              'For example: 8 false'.format(__name__)
+          )
+
+        try:
+          int(length)
+        except ValueError:
+          raise InvalidHookArgumentSyntaxError(
+            '{}: Invalid argument! Resolver requires two arguments: length (Int) and allow special chars (Bool) - '
+              'For example: 8 false'.format(__name__)
+          )
+        else:
+          size = int(length)
+
+        chars = string.ascii_letters + string.digits
+
+        if allow_chars.lower() == 'true':
+          # Use a limited subset of special chars since many DB systems have reserved chars
+          chars = chars + '~!@#$^&*_-+=|:'
+
+        password = ''.join(random.choice(chars) for i in range(size))
+        print("Generated random password of length ", size, " is: ", password)
+        return password

--- a/uc3_sceptre_utils/resolvers/password_generator.py
+++ b/uc3_sceptre_utils/resolvers/password_generator.py
@@ -46,5 +46,5 @@ class PasswordGenerator(Resolver):
           chars = chars + '~!#$^&*_-+=|:'
 
         password = ''.join(random.choice(chars) for i in range(size))
-        print("Generated random password of length ", size, " is: ", password)
+        print('{} - Generated random password: {}'.format(__name__, password))
         return password

--- a/uc3_sceptre_utils/resolvers/password_generator.py
+++ b/uc3_sceptre_utils/resolvers/password_generator.py
@@ -43,7 +43,7 @@ class PasswordGenerator(Resolver):
 
         if allow_chars.lower() == 'true':
           # Use a limited subset of special chars since many DB systems have reserved chars
-          chars = chars + '~!@#$^&*_-+=|:'
+          chars = chars + '~!#$^&*_-+=|:'
 
         password = ''.join(random.choice(chars) for i in range(size))
         print("Generated random password of length ", size, " is: ", password)


### PR DESCRIPTION
Added a new sceptre resolver that allows us to generate random strings. Example use case would be to generate random usernames and passwords for RDS instances when they are built.

Resolver requires 2 arguments: 1) length as an integer, 2) boolean to signify whether it should include special characters 
Usage in a Sceptre config file: `RdsPassword: !password_generator 12 true`