### PR TITLE
Hook that builds a Docker image and publishes to ECR

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
             'ecs_task_exec_role = uc3_sceptre_utils.hooks.ecs_task_exec_role:ECSTaskExecRole',
             'route53_hosted_zone = uc3_sceptre_utils.hooks.route53:Route53HostedZone',
             's3_bucket = uc3_sceptre_utils.hooks.s3_bucket:S3Bucket',
+            'docker_to_ecr = uc3_sceptre_utils.hooks.docker_to_ecr:DockerToEcr',
         ],
         'sceptre.resolvers': [
             'acm_certificate_arn = uc3_sceptre_utils.resolvers.acm_certificate_arn:AcmCertificateArn',

--- a/uc3_sceptre_utils/hooks/docker_to_ecr.py
+++ b/uc3_sceptre_utils/hooks/docker_to_ecr.py
@@ -25,7 +25,7 @@ class DockerToEcr(Hook):
     :region:   Optional. The AWS region. The default is us-west-2.
 
     Example:
-        !docker_to_ecr ecr_name=my-ecr ecr_uri=01234567.dkr.ecr.us-west-2.amazonaws.com/my-ecr location=src/my_app
+        !docker_to_ecr ecr_name=/uc3/svc/sub-svc/env/EcrName ecr_uri=/uc3/svc/sub-svc/env/EcrUri location=src/my_app
 
     Note this hook requires Docker to be installed and its daemon should be running.
     """
@@ -76,7 +76,7 @@ class DockerToEcr(Hook):
 def main():
     """
     test docker_to_ecr hook actions:
-        python ./docker_to_ecr ecr_name=my-ecr ecr_uri=1234567.dkr.ecr.us-west-2.amazonaws.com/my-ecr location=src/my_app
+        python ./docker_to_ecr ecr_name=/uc3/svc/sub-svc/env/EcrName ecr_uri=/uc3/svc/sub-svc/env/EcrUri location=src/my_app
     """
 
     request = DockerToEcr(argument=' '.join(sys.argv[1:]))

--- a/uc3_sceptre_utils/hooks/docker_to_ecr.py
+++ b/uc3_sceptre_utils/hooks/docker_to_ecr.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+import sys
+import os
+import subprocess
+import boto3
+
+from sceptre.hooks import Hook
+from sceptre.exceptions import InvalidHookArgumentSyntaxError
+
+DEFAULT_REGION = 'us-west-2'
+
+class DockerToEcr(Hook):
+    """
+    A Sceptre Hook object for packaging an application as a Docker image and pushing the image to ECR.
+
+    self.argument is parsed as a string of keyword args.
+    After parsing, the following keywords are accepted:
+
+    :ecr_name: Required. SSM key for the parameter containing the ECR name (e.g. /uc3/dmp/hub/dev/EcrName).
+                         Example parameter value: 'my-ecr'
+    :ecr_uri:  Required. SSM key for the parameter containing the ECR URI (e.g. /uc3/dmp/hub/dev/EcrUri).
+                         Example parameter value: '01234567.dkr.ecr.us-west-2.amazonaws.com/my-ecr'
+    :location: Required. The location of the folder, from wihtin the project dir, that contains the
+                         Dockerfile. (e.g. src/my_app)
+    :region:   Optional. The AWS region. The default is us-west-2.
+
+    Example:
+        !docker_to_ecr ecr_name=my-ecr ecr_uri=01234567.dkr.ecr.us-west-2.amazonaws.com/my-ecr location=src/my_app
+
+    Note this hook requires Docker to be installed and its daemon should be running.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(DockerToEcr, self).__init__(*args, **kwargs)
+
+    def run(self):
+        kwargs = dict()
+        for item in self.argument.split():
+            k, v = item.split('=')
+            kwargs[k] = v
+        required_args = ['ecr_name', 'ecr_uri', 'location']
+        for arg in required_args:
+            if not arg in kwargs:
+                raise InvalidHookArgumentSyntaxError(
+                    '{}: required kwarg "{}" not found'.format(__name__, arg)
+                )
+
+        region = kwargs.get('region', DEFAULT_REGION)
+        ecr_name = self.fetch_ssm_parameter(kwargs['ecr_name'])
+        ecr_uri = self.fetch_ssm_parameter(kwargs['ecr_uri'])
+        ecr_short_uri = ecr_uri.replace(ecr_name, '').split('/')[0]
+
+        print('{}: Logging into ECR ...'.format(__name__))
+        os.system('aws ecr get-login-password --region {} | docker login --username AWS --password-stdin {}'.format(region, ecr_short_uri))
+
+        cwd = subprocess.run('pwd', stdout=subprocess.PIPE, text=True)
+        lambda_path = os.path.join(cwd.stdout.strip(), kwargs['location'])
+
+        print("{}: Building Docker image in: {} ...".format(__name__, lambda_path))
+        os.chdir(lambda_path)
+        os.system('docker build -t {} .'.format(ecr_name))
+        os.system('docker tag {}:latest {}:latest'.format(ecr_name, ecr_uri))
+
+        print("{}: Pushing Docker image to ECR: {}:latest ...".format(__name__, ecr_uri))
+        os.system('docker push {}:latest'.format(ecr_uri))
+
+    def fetch_ssm_parameter(_self, key):
+      ssm = boto3.client('ssm')
+      try:
+          response = ssm.get_parameter(Name=key, WithDecryption=True)
+      except Exception:
+          print('{} - parameter name not found: {}'.format(__name__, key))
+          return None
+      return response['Parameter']['Value']
+
+def main():
+    """
+    test docker_to_ecr hook actions:
+        python ./docker_to_ecr ecr_name=my-ecr ecr_uri=1234567.dkr.ecr.us-west-2.amazonaws.com/my-ecr location=src/my_app
+    """
+
+    request = DockerToEcr(argument=' '.join(sys.argv[1:]))
+    request.run()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Added new hook that will build a docker image and push it to an ECR. The primary use case is when first creating an environment for a service. Lambda and ECS resources require that the code/image is available when creating the resource (for example CF cannot create a Lambda unless you give it the code)

Example usage:
```
# Sceptre config: config/dev/ecr.yaml
# -----------------------------------------------------------
template:
  path: ecr.yaml
  type: file

parameters:
  Name: 'my-ecr'

hooks:
  after_create:
    # The Fargate and Pipeline templates require that the ECR contains an image. This hook will build
    # the Docker image and push it to ECR. The CodePipeline will handle builds and deploys afterward
    - !docker_to_ecr dockerfile_dir=src/ecs ssm_path=/uc3/dmp/hub/dev ecr_name=/EcrName ecr_uri=EcrUri

# Sceptre template: templates/ecr.yaml
# -----------------------------------------------------------
AWSTemplateFormatVersion: '2010-09-09'
Transform: 'AWS::Serverless-2016-10-31'

Parameters:
  SsmPath:
    Type: 'String'

  EcrLifecyclePolicyTagPrefix:
    Type: 'String'
    Default: 'latest'

Resources:
  ECRRepository:
    Type: 'AWS::ECR::Repository'
    DeletionPolicy: Retain
    Properties:
      RepositoryName: !Ref AWS::StackName

  # Add the ECR URI and Name to SSM 
  EcrUriParameter:
    Type: 'AWS::SSM::Parameter'
    Properties:
      Description: !Sub "${AWS::StackName} ECR URI"
      Name: !Sub "${SsmPath}EcrUri"
      # Note: AWS CloudFormation does not yet support creating a SecureString parameter type.
      Type: 'String'
      Value: !GetAtt ECRRepository.RepositoryUri

  EcrNameParameter:
    Type: 'AWS::SSM::Parameter'
    Properties:
      Description: !Sub "${AWS::StackName} ECR Name"
      Name: !Sub "${SsmPath}EcrName"
      Type: 'String'
      Value: !Ref AWS::StackName
```