### PR TITLE
Hook that builds and deploys a SAM project

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
             'ecs_task_exec_role = uc3_sceptre_utils.hooks.ecs_task_exec_role:ECSTaskExecRole',
             'route53_hosted_zone = uc3_sceptre_utils.hooks.route53:Route53HostedZone',
             's3_bucket = uc3_sceptre_utils.hooks.s3_bucket:S3Bucket',
+            'sam_deploy = uc3_sceptre_utils.hooks.sam_deploy:SamDeploy',
         ],
         'sceptre.resolvers': [
             'acm_certificate_arn = uc3_sceptre_utils.resolvers.acm_certificate_arn:AcmCertificateArn',

--- a/uc3_sceptre_utils/hooks/sam_deploy.py
+++ b/uc3_sceptre_utils/hooks/sam_deploy.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+import sys
+import os
+import subprocess
+import boto3
+
+from sceptre.hooks import Hook
+from sceptre.exceptions import InvalidHookArgumentSyntaxError
+
+DEFAULT_REGION = 'us-west-2'
+
+class SamDeploy(Hook):
+    """
+    A Sceptre Hook object for triggering the build and deploy of AWS SAM
+
+    self.argument is parsed as a string of keyword args.
+    After parsing, the following keywords are accepted:
+
+    :location: Required. The location of the SAM code from within the project directory. (e.g. src/sam/)
+    :config:   Required. The name of the config environment to use (e.g. dev)
+    :region:   Optional. The AWS region. The default is us-west-2.
+
+    Example:
+        !deploy_sam location=src/same
+
+    Note this hook requires Docker to be installed and its daemon should be running.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(SamDeploy, self).__init__(*args, **kwargs)
+
+    def run(self):
+        kwargs = dict()
+        for item in self.argument.split():
+            k, v = item.split('=')
+            kwargs[k] = v
+        required_args = ['location', 'config']
+        for arg in required_args:
+            if not arg in kwargs:
+                raise InvalidHookArgumentSyntaxError(
+                    '{}: required kwarg "{}" not found'.format(__name__, arg)
+                )
+
+        region = kwargs.get('region', DEFAULT_REGION)
+
+        os.chdir(kwargs['location'])
+        print('{}: Building SAM application ...'.format(__name__))
+        os.system('sam build')
+
+        print('{}: Deploying SAM application ...'.format(__name__))
+        os.system('sam deploy --config-env {}'.format(kwargs['config']))
+
+def main():
+    """
+    test deploy_sam hook actions:
+        python ./deploy_sam location=src/sam
+    """
+
+    request = SamDeploy(argument=' '.join(sys.argv[1:]))
+    request.run()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This Hook will build and deploy an AWS SAM project. The primary use case is when first creating an environment for a service. For example if the service's Lambda code and API Gateway are managed via SAM, a hook can be executed after required resources are created but before additional resources that rely on those Lambdas or API Gateway. 
```
hooks:
  after_create:
    # Once the Dynamo table has been created, we can deploy our Lambdas and the API Gateway which are managed
    # by AWS SAM.
    - !sam_deploy location=src/sam config=dev
```
Note that it expects your SAM environment to use a `samconfig.toml` ([see the SAM docs](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-config.html)). For example:
```
version = 0.1
[dev]
[dev.deploy]
[dev.deploy.parameters]
stack_name = "uc3-dmp-hub-dev-lambdas"
s3_bucket = "uc3-dmp-hub-dev-s3-s3privatebucket-1234567"
s3_prefix = "uc3-dmp-hub-dev-lambdas"
region = "us-west-2"
confirm_changeset = true
capabilities = "CAPABILITY_NAMED_IAM"
disable_rollback = false
image_repositories = []
```